### PR TITLE
Update Dolphin.Controllers.cs

### DIFF
--- a/emulatorLauncher/Generators/Dolphin.Controllers.cs
+++ b/emulatorLauncher/Generators/Dolphin.Controllers.cs
@@ -307,10 +307,10 @@ namespace emulatorLauncher
 
             using (IniFile ini = new IniFile(iniFile, IniOptions.UseSpaces))
             {
-                for (int i = 0; i < 5; i++)
+                for (int i = 1; i < 5; i++)
                 {
-                    ini.ClearSection("[" + anyDefKey + i.ToString() + "]");
-                    ini.WriteValue("[" + anyDefKey + i.ToString() + "]", "Source", "2");
+                    ini.ClearSection(anyDefKey + i.ToString());
+                    ini.WriteValue(anyDefKey + i.ToString(), "Source", "2");
                 }
 
                 ini.Save();


### PR DESCRIPTION
When using real wiimotes, the system was wrongly generating WiimoteNew.ini:
- Doubling the [ (e.g. [ [ WiimoteX ] ] instead of [ WiimoteX ]
- Starting with Wiimote0 instead od Wiimote1